### PR TITLE
add support for force_redirect option in HTTPoison

### DIFF
--- a/lib/eventsource_ex.ex
+++ b/lib/eventsource_ex.ex
@@ -16,15 +16,17 @@ defmodule EventsourceEx do
     headers = opts[:headers]
     parent = opts[:stream_to]
     follow_redirect = opts[:follow_redirect]
+    hackney_opts = opts[:hackney]
     ssl = opts[:ssl]
     http_options = [stream_to: self(), ssl: ssl, follow_redirect: follow_redirect,
-                                  recv_timeout: :infinity]
+                                  hackney: hackney_opts, recv_timeout: :infinity]
 
     {url, headers, parent, Enum.filter(http_options, fn({_,val}) -> val != nil end)}
   end
     
   def init(opts \\ []) do
     {url, headers, parent, options} = parse_options(opts)
+    Logger.debug(fn -> "starting stream with http options: #{inspect options}" end)
     HTTPoison.get!(url, headers, options)
 
     {:ok, %{parent: parent, message: %EventsourceEx.Message{}, prev_chunk: nil}}

--- a/lib/eventsource_ex.ex
+++ b/lib/eventsource_ex.ex
@@ -16,9 +16,8 @@ defmodule EventsourceEx do
     headers = opts[:headers]
     parent = opts[:stream_to]
     follow_redirect = opts[:follow_redirect]
-    force_redirect = opts[:force_redirect]
     ssl = opts[:ssl]
-    http_options = [stream_to: self(), ssl: ssl, force_redirect: force_redirect, follow_redirect: follow_redirect,
+    http_options = [stream_to: self(), ssl: ssl, follow_redirect: follow_redirect,
                                   recv_timeout: :infinity]
 
     {url, headers, parent, Enum.filter(http_options, fn({_,val}) -> val != nil end)}

--- a/lib/eventsource_ex.ex
+++ b/lib/eventsource_ex.ex
@@ -16,8 +16,9 @@ defmodule EventsourceEx do
     headers = opts[:headers]
     parent = opts[:stream_to]
     follow_redirect = opts[:follow_redirect]
+    force_redirect = opts[:force_redirect]
     ssl = opts[:ssl]
-    http_options = [stream_to: self(), ssl: ssl, follow_redirect: follow_redirect,
+    http_options = [stream_to: self(), ssl: ssl, force_redirect: force_redirect, follow_redirect: follow_redirect,
                                   recv_timeout: :infinity]
 
     {url, headers, parent, Enum.filter(http_options, fn({_,val}) -> val != nil end)}


### PR DESCRIPTION
I ran into an issue with HTTPoison not handling redirects when they're `307` 
so I added handling for the entry `force_redirect`. 
This should involve no breaking changes to the api, however I think it would be cool to talk about using a keyword list just for the http options so we automatically pass down new ones as needed.
This would totally be a breaking change and as just some random contributor I'll await your opinion.

cheers 🍻 