### PR TITLE
Make http client configurable

### DIFF
--- a/lib/eventsource_ex.ex
+++ b/lib/eventsource_ex.ex
@@ -18,16 +18,17 @@ defmodule EventsourceEx do
     follow_redirect = opts[:follow_redirect]
     hackney_opts = opts[:hackney]
     ssl = opts[:ssl]
+    adapter = opts[:adapter] || HTTPoison
     http_options = [stream_to: self(), ssl: ssl, follow_redirect: follow_redirect,
                                   hackney: hackney_opts, recv_timeout: :infinity]
 
-    {url, headers, parent, Enum.filter(http_options, fn({_,val}) -> val != nil end)}
+    {url, headers, parent, adapter, Enum.filter(http_options, fn({_,val}) -> val != nil end)}
   end
 
   def init(opts \\ []) do
-    {url, headers, parent, options} = parse_options(opts)
+    {url, headers, parent, adapter, options} = parse_options(opts)
     Logger.debug(fn -> "starting stream with http options: #{inspect options}" end)
-    HTTPoison.get!(url, headers, options)
+    adapter.get!(url, headers, options)
 
     {:ok, %{parent: parent, message: %EventsourceEx.Message{}, prev_chunk: nil}}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule EventsourceEx.Mixfile do
 
       {:ex_doc, "~> 0.12.0", only: :dev, runtime: false, optional: true},
       {:dialyxir, "~> 0.5", only: :dev, runtime: false, optional: true},
+      {:mox, "~> 1.0", only: :test},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -11,6 +11,7 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "adf0218695e22caeda2820eaba703fa46c91820d53813a2223413da3ef4ba515"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm", "7a4c8e1115a2732a67d7624e28cf6c9f30c66711a9e92928e745c255887ba465"},
+  "mox": {:hex, :mox, "1.0.1", "b651bf0113265cda0ba3a827fcb691f848b683c373b77e7d7439910a8d754d6e", [:mix], [], "hexpm", "35bc0dea5499d18db4ef7fe4360067a59b06c74376eb6ab3bd67e6295b133469"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm", "603561dc0fd62f4f2ea9b890f4e20e1a0d388746d6e20557cafb1b16950de88c"},

--- a/test/eventsource_ex_test.exs
+++ b/test/eventsource_ex_test.exs
@@ -1,8 +1,34 @@
 defmodule EventsourceExTest do
   use ExUnit.Case
-  doctest EventsourceEx
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  import Mox
+
+  setup :set_mox_from_context
+
+  test "follows events" do
+    EventsourceExTest.HTTPoisonMock
+    |> expect(:get!, fn url, _headers, options ->
+      assert url == "https://a.test"
+      target = options[:stream_to]
+
+      [
+        ":ok\n\n",
+        "event: message\n",
+        "data: 1\n\n",
+        "event: message\n",
+        "data: 2\n\n"
+      ]
+      |> Enum.map(&send(target, %{chunk: &1}))
+    end)
+
+    EventsourceEx.new("https://a.test",
+      stream_to: self(),
+      adapter: EventsourceExTest.HTTPoisonMock
+    )
+
+    assert_receive(%EventsourceEx.Message{data: "1", event: "message"})
+    assert_receive(%EventsourceEx.Message{data: "2", event: "message"})
+
+    verify!()
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
 ExUnit.start()
+
+Mox.defmock(EventsourceExTest.HTTPoisonMock, for: HTTPoison.Base)


### PR DESCRIPTION
By replacing the client with a mock, it becomes possible to test parsing and integration.

Some users might also want to replace the http client at runtime.