### PR TITLE
Don't prematurely close a message when the chunk ends

### DIFF
--- a/test/eventsource_ex_test.exs
+++ b/test/eventsource_ex_test.exs
@@ -20,9 +20,11 @@ defmodule EventsourceExTest do
         "id: 3\n",
         "data: 3\n\n",
         "id: 4\ndata: 4",
-        "\n",
+        "\n\n",
         "data: fi",
-        "ve\n\n"
+        "ve\n\n",
+        "data: 6\n",
+        "data: 7\n\n",
       ]
       |> Enum.map(&send(target, %{chunk: &1}))
     end)
@@ -37,6 +39,7 @@ defmodule EventsourceExTest do
     assert_receive(%EventsourceEx.Message{id: "3", data: "3", event: "message"})
     assert_receive(%EventsourceEx.Message{id: "4", data: "4", event: "message"})
     assert_receive(%EventsourceEx.Message{data: "five", event: "message"})
+    assert_receive(%EventsourceEx.Message{data: "6\n7", event: "message"})
 
     verify!()
   end

--- a/test/eventsource_ex_test.exs
+++ b/test/eventsource_ex_test.exs
@@ -16,7 +16,13 @@ defmodule EventsourceExTest do
         "event: message\n",
         "data: 1\n\n",
         "event: message\n",
-        "data: 2\n\n"
+        "data: 2\n\n",
+        "id: 3\n",
+        "data: 3\n\n",
+        "id: 4\ndata: 4",
+        "\n",
+        "data: fi",
+        "ve\n\n"
       ]
       |> Enum.map(&send(target, %{chunk: &1}))
     end)
@@ -28,6 +34,9 @@ defmodule EventsourceExTest do
 
     assert_receive(%EventsourceEx.Message{data: "1", event: "message"})
     assert_receive(%EventsourceEx.Message{data: "2", event: "message"})
+    assert_receive(%EventsourceEx.Message{id: "3", data: "3", event: "message"})
+    assert_receive(%EventsourceEx.Message{id: "4", data: "4", event: "message"})
+    assert_receive(%EventsourceEx.Message{data: "five", event: "message"})
 
     verify!()
   end


### PR DESCRIPTION
Improves the detection for double-newline.

It might be worthwhile to find a simpler way of achieving this fix, given the additional tests.  Carrying the trailing newline around feels awkward, and honestly I'm not entirely sure if `~r/^/` is the best choice, I found it by trial-and-error.  My thinking was that the previous approach of splitting on newlines will give different results for the overall data, depending on whether the input chunk ends in a newline.  When the chunk ends in a newline, `String.split("a\n", "\n")` gives `["a", ""]`, which is hard to distinguish from the double newline `"\n\n"` for example in `String.split("a\n\nb", "\n")` which gives `["a", "", "b"]`.

Note that this patch also makes a functional difference, by allowing the processing of a chunk to begin immediately even if it doesn't end in a newline.  It might already contain a partial or several complete messages, so this seemed like a more memory-efficient way to go about things.