### PR TITLE
Fix termination error

### DIFF
--- a/lib/eventsource_ex.ex
+++ b/lib/eventsource_ex.ex
@@ -70,7 +70,7 @@ defmodule EventsourceEx do
   end
 
   def handle_info(%HTTPoison.AsyncEnd{}, state) do
-    {:stop, :connection_terminated, state}
+    {:stop, :normal, state}
   end
 
   def handle_info(_msg, state) do


### PR DESCRIPTION
I believe this should be handled as a `normal` termination. Prior to this change I was seeing:

```
12:13:13.536 [error] GenServer #PID<0.246.0> terminating
** (stop) :connection_terminated
Last message: %HTTPoison.AsyncEnd{id: #Reference<0.613309643.2773745665.193755>}
```